### PR TITLE
add QueryString and request body to TrasaT's reader

### DIFF
--- a/trasa-server/src/Trasa/Server.hs
+++ b/trasa-server/src/Trasa/Server.hs
@@ -8,6 +8,7 @@
 {-# OPTIONS_GHC -Wall -Werror #-}
 module Trasa.Server
   ( TrasaT
+  , TrasaReader(..)
   , runTrasaT
   , mapTrasaT
   , serveWith
@@ -37,8 +38,13 @@ import Trasa.Core
 
 type Headers = M.Map (CI BS.ByteString) T.Text
 
+data TrasaReader = TrasaReader
+  { trasaHeaders :: Headers
+  , trasaQueryString :: QueryString
+  }
+
 newtype TrasaT m a = TrasaT
-  { unTrasaT :: ExceptT TrasaErr (StateT Headers (ReaderT Headers m)) a
+  { unTrasaT :: ExceptT TrasaErr (StateT Headers (ReaderT TrasaReader m)) a
   } deriving
   ( Functor
   , Applicative
@@ -46,7 +52,7 @@ newtype TrasaT m a = TrasaT
   , MonadError TrasaErr
   , MonadIO
   , MonadState (M.Map (CI BS.ByteString) T.Text)
-  , MonadReader (M.Map (CI BS.ByteString) T.Text)
+  , MonadReader TrasaReader
   )
 
 instance (Monad m, Semigroup a) => Semigroup (TrasaT m a) where
@@ -67,8 +73,9 @@ instance MonadTrans TrasaT where
 runTrasaT
   :: TrasaT m a
   -> M.Map (CI BS.ByteString) T.Text -- ^ Headers
+  -> QueryString -- ^ Query string parameters
   -> m (Either TrasaErr a, M.Map (CI BS.ByteString) T.Text)
-runTrasaT trasa headers = (flip runReaderT headers . flip runStateT M.empty . runExceptT  . unTrasaT) trasa
+runTrasaT trasa headers queryStrings = (flip runReaderT (TrasaReader headers queryStrings) . flip runStateT M.empty . runExceptT  . unTrasaT) trasa
 
 mapTrasaT :: (forall x. m x -> n x) -> TrasaT m a -> TrasaT n a
 mapTrasaT eta = TrasaT . mapExceptT (mapStateT (mapReaderT eta)) . unTrasaT
@@ -95,9 +102,10 @@ serveWith toMeta makeResponse madeRouter =
           Just accepts -> do
             content <- for (M.lookup hContentType headers >>= N.parseAccept . TE.encodeUtf8) $ \typ ->
               Content typ <$> WAI.strictRequestBody req
-            let url = Url (WAI.pathInfo req) (decodeQuery (WAI.queryString req))
+            let queryStrings = decodeQuery (WAI.queryString req)
+                url = Url (WAI.pathInfo req) queryStrings
                 dispatch = dispatchWith toMeta makeResponse madeRouter method accepts url content
-            runTrasaT dispatch headers >>= \case
+            runTrasaT dispatch headers queryStrings >>= \case
               (resErr,newHeaders) -> case join resErr of
                 Left (TrasaErr stat errBody) ->
                   respond (WAI.responseLBS stat (encodeHeaders newHeaders) errBody)

--- a/trasa-server/trasa-server.cabal
+++ b/trasa-server/trasa-server.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.2
 name:
   trasa-server
 version:
-  0.4
+  0.5
 synopsis:
   Type safe web server
 description:


### PR DESCRIPTION
my motivation for this is basically just to make it easier to write libraries around trasa.
for something like a formlet library it's reasonable to assume that it's necessary to recover query string parameters which aren't embedded in the route's type.